### PR TITLE
Add extend() method (#17)

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- extend() method added to rolling objects
+
 ## [0.2.0] - 2018-05-12
 ### Added
 - Add this changelog to the doc directory
@@ -17,7 +20,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add Kurtosis class
 
 ### Removed
-
 - Remove general rolling() function
 
 

--- a/rolling/tests/test_common_methods.py
+++ b/rolling/tests/test_common_methods.py
@@ -1,0 +1,82 @@
+from rolling import Apply
+
+
+def test_extend_iterator_fixed_window_size_1():
+    seq = [0, 1]
+    roll = Apply(seq, 1, operation=list)
+
+    assert next(roll) == [0]
+    assert next(roll) == [1]
+    assert next(roll, None) is None
+
+    # extend after iterable has been exhausted
+    roll.extend([2, 3])
+    assert next(roll) == [2]
+
+    # extend while iterable is still running
+    roll.extend([4])
+    assert next(roll) == [3]
+    assert next(roll) == [4]
+    assert next(roll, None) is None
+
+
+def test_extend_iterator_fixed_window_size_3():
+    seq = [0, 1, 2]
+    roll = Apply(seq, 3, operation=list)
+
+    assert next(roll) == [0, 1, 2]
+    assert next(roll, None) is None
+
+    # extend after iterable has been exhausted
+    roll.extend([3, 4])
+    assert next(roll) == [1, 2, 3]
+
+    # extend while iterable is still running
+    roll.extend([5])
+    assert next(roll) == [2, 3, 4]
+    assert next(roll) == [3, 4, 5]
+    assert next(roll, None) is None
+
+
+def test_extend_iterator_fixed_window_size_3_original_too_short():
+    seq = [0, 1]
+    roll = Apply(seq, 3, operation=list)
+    assert next(roll, None) is None
+
+    roll.extend([2, 3])
+    assert next(roll) == [0, 1, 2]
+    assert next(roll) == [1, 2, 3]
+    assert next(roll, None) is None
+
+
+def test_extend_iterator_variable_window_size_3():
+    seq = [0, 1]
+    roll = Apply(seq, 3, window_type="variable", operation=list)
+
+    assert next(roll) == [0]
+    assert next(roll) == [0, 1]
+
+    # extend while window is growing
+    roll.extend([2])
+    assert next(roll) == [0, 1, 2]
+
+    # extend while the window is at full size
+    roll.extend([3, 4])
+    assert next(roll) == [1, 2, 3]
+    assert next(roll) == [2, 3, 4]
+    assert next(roll) == [3, 4]
+
+    # extend while the window is shrinking
+    roll.extend([5, 6])
+    assert next(roll) == [3, 4, 5]
+    assert next(roll) == [4, 5, 6]
+    assert next(roll) == [5, 6]
+    assert next(roll) == [6]
+    assert next(roll, None) is None
+
+    # extend after the iterator has been exhausted
+    roll.extend([7, 8])
+    assert next(roll) == [6, 7]
+    assert next(roll) == [6, 7, 8]
+    assert next(roll) == [7, 8]
+    assert next(roll) == [8]


### PR DESCRIPTION
Adds an `extend()` method to the rolling objects.

For example:

```python
>>> seq = [1, 6, 3, 5, 2]
>>> roll = rolling.Max(seq, 3)
>>> list(roll)     # exhaust iterable
[6, 6, 5]

>>> seq.extend([4, 0])    # extend iterable with two new integers
>>> list(roll)            # two more max window values can be returned
[5, 4]
```