### PR TITLE
Add indexed support to rolling base class

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A collection of computationally efficient rolling window iterators for Python.
 
-Useful arithmetical, logical and statistical operations on rolling windows (including `Sum`, `Min`, `Max`, `Mean`, `Median` and more). Both fixed-length and variable-length windows are supported for most operations.
+Useful arithmetical, logical and statistical operations on rolling windows (including `Sum`, `Min`, `Max`, `Mean`, `Median` and more). Both fixed-length and variable-length windows are supported for most operations. Many operations also support "indexed" windows.
 
 To get started, see the [Overview](https://github.com/ajcr/rolling#overview) section below, or have a look at the some [recipes](https://github.com/ajcr/rolling/blob/master/doc/recipes.md).
 
@@ -52,6 +52,8 @@ This library implements efficient ways to perform useful operations on rolling w
 >>> list(roll)
 [5, 9, 9] 
 ```
+
+Note that these time complexity values apply to "fixed" and "variable" window types (not the "indexed" window type which depends on the index values encountered).
 
 ## Operations
 
@@ -127,6 +129,21 @@ This allows windows smaller than the specified size to be evaluated at the begin
  (1, 5, 9),
  (5, 9, 2),
  (9, 2),
+ (2,)]
+```
+
+If values are indexed by a monotoncally-increasing index (e.g. with an integer key, timestamp or datetime) then the indexed window type can be used. The size of the window is the maximum distance between the oldest and newest values (e.g. an integer, or timedelta):
+```python
+>>> idx = [0, 1, 2, 6, 7, 11, 15]
+>>> seq = [3, 1, 4, 1, 5,  9,  2]
+>>> roll_list_idx = rolling.Apply(zip(idx, seq), window_size=3, operation=tuple, window_type='indexed')
+>>> list(roll_list_idx)
+[(3,),
+ (3, 1),
+ (3, 1, 4),
+ (1,),
+ (1, 5),
+ (9,),
  (2,)]
 ```
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -6,9 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.5.0]
 ### Added
-- New `rolling.ApplyPairwise` object
+- New `rolling.ApplyPairwise` object.
+- Add `"indexed"` window type to enable operations on windows with an index.
 
-## [0.4.0]
+## [0.4.0] - 2023-03-11
 ### Added
 - `__version__` attribute added to package
 - New `rolling.PolynomialHash()` object

--- a/rolling/apply.py
+++ b/rolling/apply.py
@@ -51,12 +51,12 @@ class Apply(RollingObject):
     """
 
     def _init_fixed(self, iterable, window_size, operation=sum, **kwargs):
-        head = islice(self._iterator, window_size - 1)
-        self._buffer = deque(head, maxlen=window_size)
+        self._buffer = deque([None])
+        self._buffer.extend(islice(self._iterator, window_size - 1))
         self._operation = operation
 
     def _init_variable(self, iterable, window_size, operation=sum, **kwargs):
-        self._buffer = deque(maxlen=window_size)
+        self._buffer = deque()
         self._operation = operation
 
     @property
@@ -70,7 +70,8 @@ class Apply(RollingObject):
         self._buffer.popleft()
 
     def _update_window(self, new):
-        self._buffer.append(new)
+        self._add_new(new)
+        self._remove_old()
 
     @property
     def _obs(self):

--- a/rolling/arithmetic/nunique.py
+++ b/rolling/arithmetic/nunique.py
@@ -42,13 +42,13 @@ class Nunique(RollingObject):
 
     def _init_fixed(self, iterable, window_size, **kwargs):
         head = islice(self._iterator, window_size - 1)
-        self._buffer = deque(head, maxlen=window_size)
+        self._buffer = deque(head)
         # append a dummy value that is removed when next() is called
         self._buffer.appendleft("dummy_value")
         self._counter = Counter(self._buffer)
 
     def _init_variable(self, iterable, window_size, **kwargs):
-        self._buffer = deque(maxlen=window_size)
+        self._buffer = deque()
         self._counter = Counter()
 
     def _update_window(self, new):

--- a/rolling/arithmetic/product.py
+++ b/rolling/arithmetic/product.py
@@ -42,7 +42,7 @@ class Product(RollingObject):
 
     def _init_fixed(self, iterable, window_size, **kwargs):
         head = islice(self._iterator, window_size - 1)
-        self._buffer = deque(head, maxlen=window_size)
+        self._buffer = deque(head)
         self._zero_count = 0
 
         prod = 1
@@ -57,7 +57,7 @@ class Product(RollingObject):
         self._product = prod
 
     def _init_variable(self, iterable, window_size, **kwargs):
-        self._buffer = deque(maxlen=window_size)
+        self._buffer = deque()
         self._zero_count = 0
         self._product = 1
 

--- a/rolling/arithmetic/sum.py
+++ b/rolling/arithmetic/sum.py
@@ -46,7 +46,7 @@ class Sum(RollingObject):
         self._sum = sum(self._buffer)
 
     def _init_variable(self, iterable, window_size, **kwargs):
-        self._buffer = deque(maxlen=window_size)
+        self._buffer = deque()
         self._sum = 0
 
     def _update_window(self, new):

--- a/rolling/entropy.py
+++ b/rolling/entropy.py
@@ -152,3 +152,6 @@ class Entropy(RollingObject):
 
     def _remove_old(self):
         pass
+
+    def _init_indexed(self, *args, **kwargs):
+        raise NotImplementedError("window_type='indexed'")

--- a/rolling/hash.py
+++ b/rolling/hash.py
@@ -102,3 +102,6 @@ class PolynomialHash(RollingObject):
     @property
     def _obs(self):
         return len(self._buffer)
+
+    def _init_indexed(self, *args, **kwargs):
+        raise NotImplementedError("window_type='indexed'")

--- a/rolling/logical/all.py
+++ b/rolling/logical/all.py
@@ -73,3 +73,6 @@ class All(RollingObject):
     def current_value(self):
         return self._i - self._window_obs >= self._last_false
 
+    def _init_indexed(self, *args, **kwargs):
+        raise NotImplementedError("window_type='indexed'")
+

--- a/rolling/logical/any.py
+++ b/rolling/logical/any.py
@@ -72,3 +72,6 @@ class Any(RollingObject):
     @property
     def current_value(self):
         return self._i - self._window_obs < self._last_true
+
+    def _init_indexed(self, *args, **kwargs):
+        raise NotImplementedError("window_type='indexed'")

--- a/rolling/minmax.py
+++ b/rolling/minmax.py
@@ -91,6 +91,9 @@ class Min(RollingObject):
     def current_value(self):
         return _value(self._buffer[0])
 
+    def _init_indexed(self, *args, **kwargs):
+        raise NotImplementedError("window_type='indexed'")
+
 
 class Max(RollingObject):
     """
@@ -173,6 +176,8 @@ class Max(RollingObject):
     def current_value(self):
         return _value(self._buffer[0])
 
+    def _init_indexed(self, *args, **kwargs):
+        raise NotImplementedError("window_type='indexed'")
 
 class MinHeap(RollingObject):
     """
@@ -247,3 +252,6 @@ class MinHeap(RollingObject):
     @property
     def current_value(self):
         return _value(self._heap[0])
+
+    def _init_indexed(self, *args, **kwargs):
+        raise NotImplementedError("window_type='indexed'")

--- a/rolling/stats/kurtosis.py
+++ b/rolling/stats/kurtosis.py
@@ -62,6 +62,13 @@ class Kurtosis(RollingObject):
         self._x3 = 0.0
         self._x4 = 0.0
 
+    def _init_indexed(self, iterable, window_size, **kwargs):
+        self._buffer = deque()
+        self._x1 = 0.0
+        self._x2 = 0.0
+        self._x3 = 0.0
+        self._x4 = 0.0
+
     def _add_new(self, new):
         self._buffer.append(new)
 

--- a/rolling/stats/median.py
+++ b/rolling/stats/median.py
@@ -55,12 +55,13 @@ class Median(RollingObject):
         tracker="sortedlist",
     ):
 
-        self._buffer = deque(maxlen=window_size)
+        self._buffer = deque()
 
-        if tracker == "skiplist":
-            self._tracker = IndexableSkiplist(window_size)
-        elif tracker == "sortedlist":
+
+        if tracker == "sortedlist":
             self._tracker = SortedList()
+        elif tracker == "skiplist":
+            self._tracker = IndexableSkiplist(window_size)
         else:
             raise ValueError(f"tracker must be one of 'skiplist' or 'sortedlist'")
 

--- a/rolling/stats/mode.py
+++ b/rolling/stats/mode.py
@@ -58,7 +58,7 @@ class Mode(RollingObject):
         self._bicounter.increment("DUMMY_VALUE")
 
     def _init_variable(self, iterable, window_size, return_count=False, **kwargs):
-        self._buffer = deque(maxlen=window_size)
+        self._buffer = deque()
         self.return_count = return_count
         self._bicounter = BiCounter()
 

--- a/rolling/stats/skew.py
+++ b/rolling/stats/skew.py
@@ -61,6 +61,12 @@ class Skew(RollingObject):
         self._x2 = 0.0
         self._x3 = 0.0
 
+    def _init_indexed(self, iterable, window_size, **kwargs):
+        self._buffer = deque()
+        self._x1 = 0.0
+        self._x2 = 0.0
+        self._x3 = 0.0
+
     def _add_new(self, new):
         self._buffer.append(new)
 

--- a/rolling/stats/variance.py
+++ b/rolling/stats/variance.py
@@ -65,6 +65,12 @@ class Var(RollingObject):
         self._mean = 0.0  # mean of values
         self._sslm = 0.0  # sum of squared values less the mean
 
+    def _init_indexed(self, iterable, window_size, ddof=1, **kwargs):
+        self.ddof = ddof
+        self._buffer = deque()
+        self._mean = 0.0  # mean of values
+        self._sslm = 0.0  # sum of squared values less the mean
+
     def _add_new(self, new):
         self._buffer.append(new)
 

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -74,3 +74,73 @@ def test_rolling_apply_variable(array, window_size, expected):
 def test_rolling_apply_over_short_iterable(array, window_type, expected):
     r = Apply(array, 5, operation=list, window_type=window_type)
     assert list(r) == expected
+
+
+@pytest.mark.parametrize(
+    "index_values", [
+        list(
+            zip(
+                [1, 2, 3, 7, 8, 9, 10, 11],
+                [5, 6, 4, 0, 2, 1, 21, 17],
+            )
+        )
+    ],
+)
+@pytest.mark.parametrize(
+    "window_size, expected",
+    [
+        (1, [[5], [6], [4], [0], [2], [1], [21], [17]]),
+        (2, [[5], [5, 6], [6, 4], [0], [0, 2], [2, 1], [1, 21], [21, 17]]),
+        (
+            5,
+            [
+                [5],
+                [5, 6],
+                [5, 6, 4],
+                [4, 0],
+                [0, 2],
+                [0, 2, 1],
+                [0, 2, 1, 21],
+                [0, 2, 1, 21, 17],
+            ]
+        ),
+        (
+            30,
+            [
+                [5],
+                [5, 6],
+                [5, 6, 4],
+                [5, 6, 4, 0],
+                [5, 6, 4, 0, 2],
+                [5, 6, 4, 0, 2, 1],
+                [5, 6, 4, 0, 2, 1, 21],
+                [5, 6, 4, 0, 2, 1, 21, 17],
+            ]
+        ),
+    ],
+)
+def test_rolling_apply_indexed_window(index_values, window_size, expected):
+    r = Apply(index_values, window_size, operation=list, window_type="indexed")
+    assert list(r) == expected
+
+
+@pytest.mark.parametrize(
+    "index_values", [
+        list(
+            zip(
+                [1, 2, 2, 2, 7, 8, 8, 10],
+                [5, 6, 4, 0, 2, 1, 9, 16],
+            )
+        )
+    ],
+)
+@pytest.mark.parametrize(
+    "window_size, expected",
+    [
+        (1, [[5], [6], [6, 4], [6, 4, 0], [2], [1], [1, 9], [16]]),
+        (3, [[5], [5, 6], [5, 6, 4], [5, 6, 4, 0], [2], [2, 1], [2, 1, 9], [1, 9, 16]]),
+    ],
+)
+def test_rolling_apply_indexed_window_repeated_indices(index_values, window_size, expected):
+    r = Apply(index_values, window_size, operation=list, window_type="indexed")
+    assert list(r) == expected

--- a/tests/test_arithmetic.py
+++ b/tests/test_arithmetic.py
@@ -11,6 +11,25 @@ def _product(it):
     return x
 
 
+def _nunique(it):
+    return len(set(it))
+
+
+INDEXED_VALUES = list(
+    zip(
+        [1, 2, 3, 7, 8, 9, 10, 11, 20],
+        [5, 6, 4, 0, 2, 1, 21, 17, 33],
+    )
+)
+
+INDEXED_VALUES_2 = list(
+    zip(
+        [1, 2, 3, 7, 8, 9, 10, 11, 20, 23, 24],
+        [5, 6, 5, 5, 4, 3,  5,  7,  3,  3,  3],
+    )
+)
+
+
 @pytest.mark.parametrize(
     "array",
     [
@@ -26,6 +45,14 @@ def _product(it):
 def test_rolling_sum(array, window_size, window_type):
     got = Sum(array, window_size, window_type=window_type)
     expected = Apply(array, window_size, operation=sum, window_type=window_type)
+    assert list(got) == list(expected)
+
+
+@pytest.mark.parametrize("index_values", [INDEXED_VALUES])
+@pytest.mark.parametrize("window_size", [1, 3, 5, 7])
+def test_rolling_sum_indexed_window(index_values, window_size):
+    got = Sum(index_values, window_size, window_type="indexed")
+    expected = Apply(index_values, window_size, operation=sum, window_type="indexed")
     assert list(got) == list(expected)
 
 
@@ -47,12 +74,26 @@ def test_rolling_product(array, window_size, window_type):
     assert list(got) == list(expected)
 
 
+@pytest.mark.parametrize("index_values", [INDEXED_VALUES])
+@pytest.mark.parametrize("window_size", [1, 3, 5, 7])
+def test_rolling_product_indexed_window(index_values, window_size):
+    got = Product(index_values, window_size, window_type="indexed")
+    expected = Apply(index_values, window_size, operation=_product, window_type="indexed")
+    assert list(got) == list(expected)
+
+
 @pytest.mark.parametrize("word", ["aabbc", "xooxyzzziiismsdd", "jjjjjj", ""])
 @pytest.mark.parametrize("window_size", [1, 2, 3, 4, 5])
 @pytest.mark.parametrize("window_type", ["fixed", "variable"])
 def test_rolling_nunique(word, window_size, window_type):
     got = Nunique(word, window_size, window_type=window_type)
-    expected = Apply(
-        word, window_size, operation=lambda x: len(set(x)), window_type=window_type
-    )
+    expected = Apply(word, window_size, operation=_nunique, window_type=window_type)
+    assert list(got) == list(expected)
+
+
+@pytest.mark.parametrize("index_values", [INDEXED_VALUES_2])
+@pytest.mark.parametrize("window_size", [1, 3, 5, 7, 10])
+def test_rolling_nunique_indexed_window(index_values, window_size):
+    got = Nunique(index_values, window_size, window_type="indexed")
+    expected = Apply(index_values, window_size, operation=_nunique, window_type="indexed")
     assert list(got) == list(expected)

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -52,3 +52,29 @@ def test_rolling_jaccard_index(sequence, window_size, window_type, target_set):
     func = partial(jaccard_index, target_set)
     expected = Apply(sequence, window_size, operation=func, window_type=window_type)
     assert pytest.approx(list(got)) == list(expected)
+
+
+INDEXED_VALUES = list(
+    zip(
+        [1, 2, 3, 7, 8, 9, 10, 11, 20, 23, 24, 27],
+        [5, 6, 5, 5, 4, 1,  5,  2,  3,  3,  3,  1],
+    )
+)
+
+
+@pytest.mark.parametrize("array", [INDEXED_VALUES])
+@pytest.mark.parametrize(
+    "target_set",
+    [
+        {0},
+        {0, 1},
+        {0, 1, 2, 3},
+        {0, 1, 2, 3, 4, 5},
+    ],
+)
+@pytest.mark.parametrize("window_size", [1, 3, 5, 7])
+def test_rolling_var_indexed(array, window_size, target_set):
+    got = JaccardIndex(array, window_size, window_type="indexed", target_set=target_set)
+    func = partial(jaccard_index, target_set)
+    expected = Apply(array, window_size, operation=func, window_type="indexed")
+    assert pytest.approx(list(got)) == list(expected)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -87,6 +87,22 @@ def test_rolling_mean(array, window_size, window_type):
     assert pytest.approx(list(got)) == list(expected)
 
 
+INDEXED_VALUES = list(
+    zip(
+        [1, 2, 3, 7, 8, 9, 10, 11, 20, 23, 24, 27],
+        [5, 6, 5, 5, 4, 3,  5,  7,  3,  3,  3,  5],
+    )
+)
+
+
+@pytest.mark.parametrize("array", [INDEXED_VALUES])
+@pytest.mark.parametrize("window_size", [1, 3, 5])
+def test_rolling_mean_indexed(array, window_size):
+    got = Mean(array, window_size, window_type="indexed")
+    expected = Apply(array, window_size, operation=_mean, window_type="indexed")
+    assert pytest.approx(list(got)) == list(expected)
+
+
 # fmt: off
 ARRAYS_TO_TEST_VAR = [
     [82, 80, 14, 73, 9, 19, 60, 31, 4, 87, 38, 36, 38, 58, 20, 97, 25, 99, 79, 31, 97, 73, 79, 71, 78, 56, 73, 24, 53, 59],
@@ -105,6 +121,14 @@ ARRAYS_TO_TEST_VAR = [
 def test_rolling_var(array, window_size, window_type):
     got = Var(array, window_size, window_type=window_type)
     expected = Apply(array, window_size, operation=_var, window_type=window_type)
+    assert pytest.approx(list(got), nan_ok=True) == list(expected)
+
+
+@pytest.mark.parametrize("array", [INDEXED_VALUES])
+@pytest.mark.parametrize("window_size", [1, 3, 5, 7])
+def test_rolling_var_indexed(array, window_size):
+    got = Var(array, window_size, window_type="indexed")
+    expected = Apply(array, window_size, operation=_var, window_type="indexed")
     assert pytest.approx(list(got), nan_ok=True) == list(expected)
 
 
@@ -220,12 +244,30 @@ def test_rolling_median(array, window_size, window_type, tracker):
     assert pytest.approx(list(got)) == list(expected)
 
 
+@pytest.mark.parametrize("array", [INDEXED_VALUES])
+@pytest.mark.parametrize("window_size", [1, 3, 5, 7])
+@pytest.mark.parametrize("tracker", ["skiplist", "sortedlist"])
+def test_rolling_median_indexed(array, window_size, tracker):
+    got = Median(array, window_size, window_type="indexed", tracker=tracker)
+    expected = Apply(array, window_size, operation=_median, window_type="indexed")
+    assert list(got) == list(expected)
+
+
 @pytest.mark.parametrize("array", ["aasbbdasbfiuhf", "xxyxz", "x", ""])
 @pytest.mark.parametrize("window_size", [1, 2, 3, 4, 5])
 @pytest.mark.parametrize("window_type", ["fixed", "variable"])
 def test_rolling_mode(array, window_size, window_type):
     got = Mode(array, window_size, window_type=window_type)
     expected = Apply(array, window_size, operation=_mode, window_type=window_type)
+    # NOTE: we copy the returned set so that it is not mutated after further iteration
+    assert [set_.copy() for set_ in got] == list(expected)
+
+
+@pytest.mark.parametrize("array", [INDEXED_VALUES])
+@pytest.mark.parametrize("window_size", [1, 3, 5, 7])
+def test_rolling_mode_indexed(array, window_size):
+    got = Mode(array, window_size, window_type="indexed")
+    expected = Apply(array, window_size, operation=_mode, window_type="indexed")
     # NOTE: we copy the returned set so that it is not mutated after further iteration
     assert [set_.copy() for set_ in got] == list(expected)
 
@@ -248,6 +290,14 @@ def test_rolling_skew(array, window_size, window_type):
     assert pytest.approx(list(got), nan_ok=True) == list(expected)
 
 
+@pytest.mark.parametrize("array", [INDEXED_VALUES])
+@pytest.mark.parametrize("window_size", [1, 3, 5, 7])
+def test_rolling_skew_indexed(array, window_size):
+    got = Skew(array, window_size, window_type="indexed")
+    expected = Apply(array, window_size, operation=_skew, window_type="indexed")
+    assert pytest.approx(list(got), nan_ok=True) == list(expected)
+
+
 @pytest.mark.parametrize(
     "array",
     [
@@ -263,4 +313,12 @@ def test_rolling_skew(array, window_size, window_type):
 def test_rolling_kurtosis(array, window_size, window_type):
     got = Kurtosis(array, window_size, window_type=window_type)
     expected = Apply(array, window_size, operation=_kurtosis, window_type=window_type)
+    assert pytest.approx(list(got), nan_ok=True) == list(expected)
+
+
+@pytest.mark.parametrize("array", [INDEXED_VALUES])
+@pytest.mark.parametrize("window_size", [1, 5, 7, 15])
+def test_rolling_kurtosis_indexed(array, window_size):
+    got = Kurtosis(array, window_size, window_type="indexed")
+    expected = Apply(array, window_size, operation=_kurtosis, window_type="indexed")
     assert pytest.approx(list(got), nan_ok=True) == list(expected)


### PR DESCRIPTION
cc @daviddavo 

After some experimentation I've decided on a general way to add indexed window support to this project.

Main ideas:
- the iterable used for indexed window iterators must be of type `Iterable[tuple[T1, T2]]` where type `T1` is the index value type and supports order operations and subtraction and `T2` is the value type. If a user has separate objects `index: Iterable[T1] = ...` and `values: Iterable[T2] = ...` they need to pass in the single iterable `zip(index, values)`.
- `_next_indexed()` is added to the `RollingObject` base class and is implemented in terms of `_add_new()` and `_remove_old()`.
- initialisation for indexed windows is the same as for variable windows in most cases. An additional `deque` is initialised to hold the index separately.

This allows most of the existing rolling operations to be supported with minimal changes and no additional base classes or mixins.

Some operations will need to implement their own `_next_indexed()` and `_init_indexed()` methods to support indexed windows.

Operations not currently supported:
- any/all/monotonic
- hash/match
- min/max