### PR TITLE
Add type stubs across project

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,0 @@
-[project]
-name = "rolling"
-version = "0.1.0"
-description = "Add your description here"
-readme = "README.md"
-requires-python = ">=3.13"
-dependencies = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "rolling"
+version = "0.1.0"
+description = "Add your description here"
+readme = "README.md"
+requires-python = ">=3.13"
+dependencies = []

--- a/rolling/__init__.py
+++ b/rolling/__init__.py
@@ -11,3 +11,27 @@ from rolling.similarity import JaccardIndex
 from rolling.stats import Mean, Var, Std, Median, Mode, Skew, Kurtosis
 
 __version__ = "0.5.0"
+__all__ = [
+    "Apply",
+    "ApplyPairwise",
+    "Nunique",
+    "Product",
+    "Sum",
+    "Entropy",
+    "PolynomialHash",
+    "All",
+    "Any",
+    "Match",
+    "Min",
+    "Max",
+    "MinHeap",
+    "Monotonic",
+    "JaccardIndex",
+    "Mean",
+    "Var",
+    "Std",
+    "Median",
+    "Mode",
+    "Skew",
+    "Kurtosis",
+]

--- a/rolling/apply.py
+++ b/rolling/apply.py
@@ -1,7 +1,9 @@
 from collections import deque
 from itertools import islice
+from collections.abc import Iterable, Callable
+from typing import Any
 
-from .base import RollingObject
+from .base import RollingObject, WindowType
 
 
 class Apply(RollingObject):
@@ -49,38 +51,38 @@ class Apply(RollingObject):
      [5, 6, 3, 1]]
 
     """
-    def __init__(self, iterable, window_size, window_type="fixed", operation=sum):
+    def __init__(self, iterable: Iterable[Any], window_size: int, window_type: WindowType = "fixed", operation: Callable[..., Any]=sum):
         super().__init__(iterable, window_size, window_type)
         self._operation = operation
 
-    def _init_fixed(self):
+    def _init_fixed(self) -> None:
         self._buffer = deque([None])
         self._buffer.extend(islice(self._iterator, self.window_size - 1))
 
-    def _init_variable(self):
-        self._buffer = deque()
+    def _init_variable(self) -> None:
+        self._buffer: deque[Any] = deque()
 
-    _init_indexed = _init_variable
+    _init_indexed: Callable[..., None] = _init_variable
 
     @property
     def current_value(self):
         return self._operation(self._buffer)
 
-    def _add_new(self, new):
+    def _add_new(self, new) -> None:
         self._buffer.append(new)
 
-    def _remove_old(self):
+    def _remove_old(self) -> None:
         self._buffer.popleft()
 
-    def _update_window(self, new):
+    def _update_window(self, new) -> None:
         self._add_new(new)
         self._remove_old()
 
     @property
-    def _obs(self):
+    def _obs(self) -> int:
         return len(self._buffer)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "Rolling(operation='{}', window_size={}, window_type='{}')".format(
             self._operation.__name__, self.window_size, self.window_type
         )

--- a/rolling/apply_pairwise.py
+++ b/rolling/apply_pairwise.py
@@ -1,9 +1,9 @@
 from collections import deque
 from itertools import islice
-
+from collections.abc import Iterable, Callable
 from .base_pairwise import RollingPairwise
-
-
+from typing import Any
+from .base import WindowType
 class ApplyPairwise(RollingPairwise):
     """
     Apply a binary function to windows over two iterables.
@@ -38,42 +38,42 @@ class ApplyPairwise(RollingPairwise):
     [1.0, 0.0, -1.0]
 
     """
-    def __init__(self, iterable_1, iterable_2, window_size, function, window_type="fixed"):
+    def __init__(self, iterable_1: Iterable[Any], iterable_2: Iterable[Any], window_size: int, function: Callable[..., Any], window_type: WindowType="fixed") -> None:
         self._buffer_1 = deque(maxlen=window_size)
         self._buffer_2 = deque(maxlen=window_size)
         self._function = function
         super().__init__(iterable_1, iterable_2, window_size=window_size, window_type=window_type)
 
-    def _init_fixed(self):
+    def _init_fixed(self) -> None:
         pairs = zip(self._iterator_1, self._iterator_2)
         for item_1, item_2 in islice(pairs, self.window_size-1):
             self._buffer_1.append(item_1)
             self._buffer_2.append(item_2)
 
-    def _init_variable(self):
+    def _init_variable(self) -> None:
         pass # no action required
 
     @property
     def current_value(self):
         return self._function(self._buffer_1, self._buffer_2)
 
-    def _add_new(self, new_1, new_2):
+    def _add_new(self, new_1, new_2) -> None:
         self._buffer_1.append(new_1)
         self._buffer_2.append(new_2)
 
-    def _remove_old(self):
+    def _remove_old(self) -> None:
         self._buffer_1.popleft()
         self._buffer_2.popleft()
 
-    def _update_window(self, new_1, new_2):
+    def _update_window(self, new_1, new_2) -> None:
         self._buffer_1.append(new_1)
         self._buffer_2.append(new_2)
 
     @property
-    def _obs(self):
+    def _obs(self) -> int:
         return len(self._buffer_1)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "RollingPairwise(operation='{}', window_size={}, window_type='{}')".format(
             self._function.__name__, self.window_size, self.window_type
         )

--- a/rolling/arithmetic/__init__.py
+++ b/rolling/arithmetic/__init__.py
@@ -1,3 +1,4 @@
 from .nunique import Nunique
 from .product import Product
 from .sum import Sum
+__all__ = ["Sum", "Product", "Nunique"]

--- a/rolling/arithmetic/nunique.py
+++ b/rolling/arithmetic/nunique.py
@@ -1,6 +1,6 @@
 from collections import Counter, deque
 from itertools import islice
-
+from typing import Any
 from rolling.base import RollingObject
 
 
@@ -40,37 +40,37 @@ class Nunique(RollingObject):
 
     """
 
-    def _init_fixed(self):
+    def _init_fixed(self) -> None:
         head = islice(self._iterator, self.window_size - 1)
         self._buffer = deque(head)
         # append a dummy value that is removed when next() is called
         self._buffer.appendleft("dummy_value")
         self._counter = Counter(self._buffer)
 
-    def _init_variable(self):
-        self._buffer = deque()
-        self._counter = Counter()
+    def _init_variable(self) -> None:
+        self._buffer: deque[Any] = deque()
+        self._counter: Counter[int] = Counter()
 
     _init_indexed = _init_variable
 
-    def _update_window(self, new):
+    def _update_window(self, new) -> None:
         # remove oldest value before appending new to buffer
         self._remove_old()
         self._counter[new] += 1
         self._buffer.append(new)
 
-    def _add_new(self, new):
+    def _add_new(self, new) -> None:
         self._counter[new] += 1
         self._buffer.append(new)
 
-    def _remove_old(self):
+    def _remove_old(self) -> None:
         old = self._buffer.popleft()
         self._counter -= Counter([old])
 
     @property
-    def current_value(self):
+    def current_value(self) -> int:
         return len(self._counter)
 
     @property
-    def _obs(self):
+    def _obs(self) -> int:
         return len(self._buffer)

--- a/rolling/arithmetic/sum.py
+++ b/rolling/arithmetic/sum.py
@@ -1,6 +1,6 @@
 from collections import Counter, deque
 from itertools import islice
-
+from typing import Any
 from rolling.base import RollingObject
 
 
@@ -39,23 +39,23 @@ class Sum(RollingObject):
     [13, 11, 15]
 
     """
-    def _init_fixed(self):
+    def _init_fixed(self) -> None:
         head = islice(self._iterator, self.window_size - 1)
         self._buffer = deque(head, maxlen=self.window_size)
         self._buffer.appendleft(0)
-        self._sum = sum(self._buffer)
+        self._sum: int = sum(self._buffer)
 
-    def _init_variable(self):
-        self._buffer = deque()
+    def _init_variable(self) -> None:
+        self._buffer: deque[int] = deque()
         self._sum = 0
 
     _init_indexed = _init_variable
 
-    def _update_window(self, new):
+    def _update_window(self, new) -> None:
         self._sum += new - self._buffer.popleft()
         self._buffer.append(new)
 
-    def _add_new(self, new):
+    def _add_new(self, new) -> None:
         self._sum += new
         self._buffer.append(new)
 
@@ -63,9 +63,9 @@ class Sum(RollingObject):
         self._sum -= self._buffer.popleft()
 
     @property
-    def current_value(self):
+    def current_value(self) -> int:
         return self._sum
 
     @property
-    def _obs(self):
+    def _obs(self) -> int:
         return len(self._buffer)

--- a/rolling/base.py
+++ b/rolling/base.py
@@ -1,10 +1,12 @@
 import abc
 from collections import deque
-from collections.abc import Iterator
+from collections.abc import Iterator, Iterable
 from itertools import chain
+from typing import Any, Literal
 
-
-class RollingObject(Iterator):
+WindowType = Literal["fixed", "variable", "indexed"]
+Tracker = Literal["sortedlist", "skiplist"]
+class RollingObject(Iterator[Any]):
     """
     Baseclass for rolling iterator objects.
 
@@ -31,10 +33,10 @@ class RollingObject(Iterator):
 
     """
 
-    def __init__(self, iterable, window_size, window_type="fixed"):
+    def __init__(self, iterable: Iterable[Any], window_size: int, window_type: WindowType="fixed"):
         self.window_type = window_type
         self.window_size = _validate_window_size(window_size, window_type)
-        self._iterator = iter(iterable)
+        self._iterator: Iterator[Any] = iter(iterable)
         self._filled = self.window_type == "fixed"
 
         if window_type == "fixed":
@@ -47,11 +49,8 @@ class RollingObject(Iterator):
             # Keep track of all indexes that we encounter. Assumes that all
             # values we encounter will be stored in the same order. If not,
             # the subtype will need to implement its own _next_indexed() method.
-            self.index_buffer = deque()
+            self.index_buffer: deque[Any] = deque()
             self._init_indexed()
-
-        else:
-            raise ValueError(f"Unknown window_type '{window_type}'")
 
     def __repr__(self):
         return "Rolling(operation='{}', window_size={}, window_type='{}')".format(
@@ -116,7 +115,7 @@ class RollingObject(Iterator):
 
         raise NotImplementedError(f"next() not implemented for {self.window_type}")
 
-    def extend(self, iterable):
+    def extend(self, iterable: Iterable[Any]):
         """
         Extend the iterator being consumed with a new iterable.
 
@@ -196,13 +195,11 @@ class RollingObject(Iterator):
         pass
 
 
-def _validate_window_size(window_size, window_type):
+def _validate_window_size(window_size: int, window_type: WindowType) -> int:
     """
     Check if k is a positive integer
     """
     if window_type in {"fixed", "variable"}:
-        if not isinstance(window_size, int):
-            raise TypeError(f"window_size must be integer type, got {type(window_size).__name__}")
         if window_size <= 0:
             raise ValueError("window_size must be positive")
     return window_size

--- a/rolling/base_pairwise.py
+++ b/rolling/base_pairwise.py
@@ -1,14 +1,16 @@
 import abc
+from typing import Any
 from collections.abc import Iterator
 from itertools import chain
+from collections.abc import Iterable
+from .base import WindowType
 
-
-class RollingPairwise(Iterator):
+class RollingPairwise(Iterator[Any]):
     """
     Baseclass for rolling iterators over two iterables.
 
     """
-    def __init__(self, iterable_1, iterable_2, window_size, window_type="fixed"):
+    def __init__(self, iterable_1: Iterable[Any], iterable_2: Iterable[Any], window_size: int, window_type: WindowType="fixed"):
         self.window_type = window_type
         self.window_size = _validate_window_size(window_size)
         self._iterator_1 = iter(iterable_1)
@@ -118,12 +120,10 @@ class RollingPairwise(Iterator):
         pass
 
 
-def _validate_window_size(k):
+def _validate_window_size(k: int):
     """
     Check if k is a positive integer
     """
-    if not isinstance(k, int):
-        raise TypeError(f"window_size must be integer type, got {type(k).__name__}")
     if k <= 0:
         raise ValueError("window_size must be positive")
     return k

--- a/rolling/entropy.py
+++ b/rolling/entropy.py
@@ -1,11 +1,11 @@
 from collections import Counter, deque
 from itertools import islice
 from math import fsum, log2, log10, log
-
+from collections.abc import Iterable, Mapping, Hashable
 from rolling.base import RollingObject
 
 
-def _get_log_func(base):
+def _get_log_func(base: int | float | str):
     if base == 2:
         return log2
     if base == 10:
@@ -15,7 +15,7 @@ def _get_log_func(base):
     return lambda x: log(x, base)
 
 
-def entropy(seq, base=2, reference_distribution=None):
+def entropy(seq, base: int=2, reference_distribution: Mapping[Hashable, float] | None=None):
     N = len(seq)
     counts = Counter(seq)
     _log = _get_log_func(base)
@@ -27,7 +27,7 @@ def entropy(seq, base=2, reference_distribution=None):
     )
 
 
-class Entropy(RollingObject):
+class Entropy[T](RollingObject[T]):
     """
     Entropy of a rolling window.
 
@@ -79,7 +79,7 @@ class Entropy(RollingObject):
      ...]
 
     """
-    def __init__(self, iterable, window_size, base=2, reference_distribution=None):
+    def __init__(self, iterable: Iterable[T], window_size: int, base: int=2, reference_distribution : Mapping[Hashable, float] | None=None):
         if reference_distribution is not None and sum(reference_distribution.values()) != 1:
             raise ValueError("reference_distribution probabilities must sum to 1")
         self.reference_distribution = reference_distribution
@@ -139,18 +139,18 @@ class Entropy(RollingObject):
         return p * self._log(p / self.reference_distribution[value])
 
     @property
-    def current_value(self):
+    def current_value(self) -> float:
         return abs(self._entropy)
 
     @property
-    def _obs(self):
+    def _obs(self) -> int:
         return len(self._buffer)
 
     # Required, but unused as variable windows not supported
-    def _add_new(self):
+    def _add_new(self) -> None:
         pass
 
-    def _remove_old(self):
+    def _remove_old(self) -> None:
         pass
 
     def _init_indexed(self):

--- a/rolling/hash.py
+++ b/rolling/hash.py
@@ -1,14 +1,14 @@
 from collections import Counter, deque
 from itertools import islice
-
-from .base import RollingObject
-
+from collections.abc import Iterable
+from .base import RollingObject, WindowType
+from typing import Any
 
 DEF_BASE = 719
 DEF_MOD = 2 ** 61 - 1
 
 
-def polynomial_hash_sequence(seq, base=DEF_BASE, mod=DEF_MOD):
+def polynomial_hash_sequence(seq, base: int=DEF_BASE, mod: int=DEF_MOD) -> int:
     """
     Compute the polynomial hash of a sequence.
 
@@ -65,7 +65,7 @@ class PolynomialHash(RollingObject):
     """
 
     def __init__(
-        self, iterable, window_size, window_type="fixed", base=DEF_BASE, mod=DEF_MOD
+        self, iterable: Iterable[Any], window_size: int, window_type: WindowType="fixed", base=DEF_BASE, mod=DEF_MOD
     ):
         self._hash = 0
         self._base = base
@@ -96,11 +96,11 @@ class PolynomialHash(RollingObject):
         self._add_new(new)
 
     @property
-    def current_value(self):
+    def current_value(self) -> int:
         return self._hash
 
     @property
-    def _obs(self):
+    def _obs(self) -> int:
         return len(self._buffer)
 
     def _init_indexed(self):

--- a/rolling/logical/__init__.py
+++ b/rolling/logical/__init__.py
@@ -1,2 +1,3 @@
 from .all import All
 from .any import Any
+__all__ = ["All", "Any"]

--- a/rolling/logical/all.py
+++ b/rolling/logical/all.py
@@ -39,38 +39,38 @@ class All(RollingObject):
 
     """
 
-    def _init_fixed(self):
+    def _init_fixed(self) -> None:
         self._i = -1
         self._window_obs = 1
         self._last_false = -1
         for new in islice(self._iterator, self.window_size - 1):
             self._add_new(new)
 
-    def _init_variable(self):
+    def _init_variable(self) -> None:
         self._i = -1
         self._window_obs = 0
         self._last_false = -1
 
-    def _add_new(self, new):
+    def _add_new(self, new) -> None:
         self._i += 1
         self._window_obs += 1
         if not new:
-            self._last_false = self._i
+            self._last_false: int = self._i
 
-    def _update_window(self, new):
+    def _update_window(self, new) -> None:
         self._i += 1
         if not new:
             self._last_false = self._i
 
-    def _remove_old(self):
+    def _remove_old(self) -> None:
         self._window_obs -= 1
 
     @property
-    def _obs(self):
+    def _obs(self) -> int:
         return self._window_obs
 
     @property
-    def current_value(self):
+    def current_value(self) -> bool:
         return self._i - self._window_obs >= self._last_false
 
     def _init_indexed(self):

--- a/rolling/matching.py
+++ b/rolling/matching.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
-
 from .hash import PolynomialHash, polynomial_hash_sequence, DEF_BASE, DEF_MOD
-
+from collections.abc import Iterable, Sequence
+from typing import Any
 
 class Match(PolynomialHash):
     """
@@ -48,7 +48,7 @@ class Match(PolynomialHash):
     [False, False, True, False, False, False, False, True]
     """
 
-    def __init__(self, iterable, match, base=DEF_BASE, mod=DEF_MOD):
+    def __init__(self, iterable: Sequence[Any], match: Sequence[Sequence[Any]], base: int=DEF_BASE, mod: int=DEF_MOD) -> None:
 
         self.match = match
 

--- a/rolling/minmax.py
+++ b/rolling/minmax.py
@@ -137,7 +137,7 @@ class Max(RollingObject):
             self._add_new(new)
 
     def _init_variable(self):
-        self._buffer = deque()
+        self._buffer: deque[int] = deque()
         self._i = -1
         self._window_obs = 0
 

--- a/rolling/monotonic.py
+++ b/rolling/monotonic.py
@@ -1,7 +1,8 @@
 import operator
-
+from collections.abc import Iterable
+from typing import Any
 from rolling.logical.all import All
-
+from .base import WindowType
 
 COMPARE = {
     # (increasing, strict): cmp
@@ -50,12 +51,12 @@ class Monotonic(All):
 
     def __init__(
         self,
-        iterable,
-        window_size,
-        window_type="fixed",
-        increasing=True,
-        strict=False,
-        initial=None,
+        iterable: Iterable[Any],
+        window_size: int,
+        window_type: WindowType="fixed",
+        increasing: bool=True,
+        strict: bool=False,
+        initial: Any=None,
     ):
         self._compare = COMPARE[(increasing, strict)]
 

--- a/rolling/similarity.py
+++ b/rolling/similarity.py
@@ -1,8 +1,7 @@
 from collections import Counter, deque
 from itertools import islice
-from collections.abc import Hashable, Iterable, Sequence
+from collections.abc import Hashable, Iterable, Sequence, Callable
 from typing import Any
-from collections.abc import Callable
 from .base import RollingObject, WindowType
 
 

--- a/rolling/similarity.py
+++ b/rolling/similarity.py
@@ -1,10 +1,12 @@
 from collections import Counter, deque
 from itertools import islice
+from collections.abc import Hashable, Iterable, Sequence
+from typing import Any
+from collections.abc import Callable
+from .base import RollingObject, WindowType
 
-from .base import RollingObject
 
-
-def jaccard_index(a, b):
+def jaccard_index(a, b) -> float:
     a_set = set(a)
     b_set = set(b)
     return len(a_set & b_set) / len(a_set | b_set)
@@ -56,13 +58,13 @@ class JaccardIndex(RollingObject):
      0.125]
 
     """
-    def __init__(self, iterable, window_size, target_set, window_type="fixed"):
-        self._target_set = frozenset(target_set)
+    def __init__(self, iterable: Iterable[Any], window_size: int, target_set: Sequence[Hashable], window_type: WindowType="fixed"):
+        self._target_set: frozenset[Hashable] = frozenset(target_set)
         if not self._target_set:
             raise ValueError("target_set cannot be empty")
         self._buffer = deque()
-        self._intersection = Counter()
-        self._union = Counter(self._target_set)
+        self._intersection: Counter[int] = Counter()
+        self._union: Counter[Hashable] = Counter(self._target_set)
         super().__init__(iterable, window_size, window_type)
 
     def _init_fixed(self):
@@ -73,15 +75,15 @@ class JaccardIndex(RollingObject):
     def _init_variable(self):
         pass
 
-    _init_indexed = _init_variable
+    _init_indexed: Callable[..., None] = _init_variable
 
-    def _add_new(self, new):
+    def _add_new(self, new) -> None:
         self._buffer.append(new)
         self._union[new] += 1
         if new in self._target_set:
            self._intersection[new] += 1 
 
-    def _remove_old(self):
+    def _remove_old(self) -> None:
         old = self._buffer.popleft()
         for mapping in (self._intersection, self._union):
             if old in mapping:
@@ -90,14 +92,14 @@ class JaccardIndex(RollingObject):
                 else:
                     mapping[old] -= 1
 
-    def _update_window(self, new):
+    def _update_window(self, new) -> None:
         self._remove_old()
         self._add_new(new)
 
     @property
-    def current_value(self):
+    def current_value(self) -> float:
         return len(self._intersection) / len(self._union)
 
     @property
-    def _obs(self):
+    def _obs(self) -> int:
         return len(self._buffer)

--- a/rolling/stats/__init__.py
+++ b/rolling/stats/__init__.py
@@ -4,3 +4,12 @@ from .mode import Mode
 from .median import Median
 from .variance import Var, Std
 from .skew import Skew
+__all__ = [
+    "Kurtosis",
+    "Mean",
+    "Mode",
+    "Median",
+    "Var",
+    "Std",
+    "Skew",
+]

--- a/rolling/stats/kurtosis.py
+++ b/rolling/stats/kurtosis.py
@@ -35,7 +35,7 @@ class Kurtosis(RollingObject):
 
     """
 
-    def _init_fixed(self):
+    def _init_fixed(self) -> None:
         if self.window_size <= 3:
             raise ValueError("window_size must be greater than 3")
 
@@ -52,7 +52,7 @@ class Kurtosis(RollingObject):
         # the first call to update returns the correct value
         self._buffer.appendleft(0)
 
-    def _init_variable(self):
+    def _init_variable(self) -> None:
         if self.window_size <= 3:
             raise ValueError("window_size must be greater than 3")
 
@@ -62,14 +62,14 @@ class Kurtosis(RollingObject):
         self._x3 = 0.0
         self._x4 = 0.0
 
-    def _init_indexed(self):
+    def _init_indexed(self) -> None:
         self._buffer = deque()
         self._x1 = 0.0
         self._x2 = 0.0
         self._x3 = 0.0
         self._x4 = 0.0
 
-    def _add_new(self, new):
+    def _add_new(self, new) -> None:
         self._buffer.append(new)
 
         self._x1 += new
@@ -77,7 +77,7 @@ class Kurtosis(RollingObject):
         self._x3 += new ** 3
         self._x4 += new ** 4
 
-    def _remove_old(self):
+    def _remove_old(self) -> None:
         old = self._buffer.popleft()
 
         self._x1 -= old
@@ -85,7 +85,7 @@ class Kurtosis(RollingObject):
         self._x3 -= old ** 3
         self._x4 -= old ** 4
 
-    def _update_window(self, new):
+    def _update_window(self, new) -> None:
         old = self._buffer[0]
         self._buffer.append(new)
 
@@ -120,5 +120,5 @@ class Kurtosis(RollingObject):
         return K / ((N - 2) * (N - 3))
 
     @property
-    def _obs(self):
+    def _obs(self) -> int:
         return len(self._buffer)

--- a/rolling/stats/median.py
+++ b/rolling/stats/median.py
@@ -1,10 +1,11 @@
 from collections import deque
 from itertools import islice
-
+from collections.abc import Iterable
+from typing import Any
 from rolling.base import RollingObject
 from rolling.structures.skiplist import IndexableSkiplist
 from rolling.structures.sortedlist import SortedList
-
+from base import WindowType, Tracker
 
 class Median(RollingObject):
     """
@@ -49,20 +50,17 @@ class Median(RollingObject):
     """
     def __init__(
         self,
-        iterable,
-        window_size,
-        window_type="fixed",
-        tracker="sortedlist",
-    ):
+        iterable: Iterable[Any],
+        window_size: int,
+        window_type: WindowType="fixed",
+        tracker: Tracker="sortedlist",
+    ) -> None:
 
         self._buffer = deque()
         if tracker == "sortedlist":
             self._tracker = SortedList()
         elif tracker == "skiplist":
             self._tracker = IndexableSkiplist(window_size)
-        else:
-            raise ValueError(f"tracker must be one of 'skiplist' or 'sortedlist'")
-
         super().__init__(iterable, window_size, window_type)
 
     def _init_fixed(self):
@@ -87,17 +85,17 @@ class Median(RollingObject):
 
     _init_indexed = _init_variable
 
-    def _update_window(self, new):
+    def _update_window(self, new) -> None:
         old = self._buffer.popleft()
         self._tracker.remove(old)
         self._tracker.insert(new)
         self._buffer.append(new)
 
-    def _add_new(self, new):
+    def _add_new(self, new) -> None:
         self._tracker.insert(new)
         self._buffer.append(new)
 
-    def _remove_old(self):
+    def _remove_old(self) -> None:
         old = self._buffer.popleft()
         self._tracker.remove(old)
 
@@ -110,6 +108,6 @@ class Median(RollingObject):
             return (self._tracker[i] + self._tracker[i - 1]) / 2
 
     @property
-    def _obs(self):
+    def _obs(self) -> int:
         return len(self._buffer)
 

--- a/rolling/stats/median.py
+++ b/rolling/stats/median.py
@@ -5,7 +5,7 @@ from typing import Any
 from rolling.base import RollingObject
 from rolling.structures.skiplist import IndexableSkiplist
 from rolling.structures.sortedlist import SortedList
-from base import WindowType, Tracker
+from ..base import WindowType, Tracker
 
 class Median(RollingObject):
     """

--- a/rolling/stats/mode.py
+++ b/rolling/stats/mode.py
@@ -1,9 +1,10 @@
 from collections import deque
 from itertools import islice
-
+from collections.abc import Iterable
+from typing import Any
 from rolling.base import RollingObject
 from rolling.structures.bicounter import BiCounter
-
+from base import WindowType
 
 class Mode(RollingObject):
     """
@@ -45,12 +46,12 @@ class Mode(RollingObject):
     is not unique.
 
     """
-    def __init__(self, iterable, window_size, window_type="fixed", return_count=False):
+    def __init__(self, iterable: Iterable[Any], window_size: int, window_type: WindowType="fixed", return_count: bool=False) -> None:
         self.return_count = return_count
         self._bicounter = BiCounter()
         super().__init__(iterable, window_size, window_type)
 
-    def _init_fixed(self):
+    def _init_fixed(self) -> None:
         self._buffer = deque(maxlen=self.window_size)
         for item in islice(self._iterator, self.window_size - 1):
             self._add_new(item)
@@ -64,17 +65,17 @@ class Mode(RollingObject):
 
     _init_indexed = _init_variable
 
-    def _update_window(self, new):
+    def _update_window(self, new) -> None:
         old = self._buffer.popleft()
         self._bicounter.decrement(old)
         self._bicounter.increment(new)
         self._buffer.append(new)
 
-    def _add_new(self, new):
+    def _add_new(self, new) -> None:
         self._bicounter.increment(new)
         self._buffer.append(new)
 
-    def _remove_old(self):
+    def _remove_old(self) -> None:
         old = self._buffer.popleft()
         self._bicounter.decrement(old)
 
@@ -86,7 +87,7 @@ class Mode(RollingObject):
             return self._bicounter.get_most_common()
 
     @property
-    def _obs(self):
+    def _obs(self) -> int:
         return len(self._buffer)
 
 

--- a/rolling/stats/mode.py
+++ b/rolling/stats/mode.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable
 from typing import Any
 from rolling.base import RollingObject
 from rolling.structures.bicounter import BiCounter
-from base import WindowType
+from ..base import WindowType
 
 class Mode(RollingObject):
     """

--- a/rolling/stats/skew.py
+++ b/rolling/stats/skew.py
@@ -52,7 +52,7 @@ class Skew(RollingObject):
         # the first call to update returns the correct value
         self._buffer.appendleft(0)
 
-    def _init_variable(self):
+    def _init_variable(self) -> None:
         if self.window_size <= 2:
             raise ValueError("window_size must be greater than 2")
 
@@ -61,27 +61,27 @@ class Skew(RollingObject):
         self._x2 = 0.0
         self._x3 = 0.0
 
-    def _init_indexed(self):
+    def _init_indexed(self) -> None:
         self._buffer = deque()
         self._x1 = 0.0
         self._x2 = 0.0
         self._x3 = 0.0
 
-    def _add_new(self, new):
+    def _add_new(self, new) -> None:
         self._buffer.append(new)
 
         self._x1 += new
         self._x2 += new * new
         self._x3 += new * new * new
 
-    def _remove_old(self):
+    def _remove_old(self) -> None:
         old = self._buffer.popleft()
 
         self._x1 -= old
         self._x2 -= old * old
         self._x3 -= old * old * old
 
-    def _update_window(self, new):
+    def _update_window(self, new) -> None:
         old = self._buffer[0]
         self._buffer.append(new)
 

--- a/rolling/stats/variance.py
+++ b/rolling/stats/variance.py
@@ -4,7 +4,7 @@ from math import sqrt
 from collections.abc import Iterable
 from typing import Any
 from rolling.base import RollingObject
-from base import WindowType
+from ..base import WindowType
 
 class Var(RollingObject):
     """

--- a/rolling/stats/variance.py
+++ b/rolling/stats/variance.py
@@ -1,9 +1,10 @@
 from collections import deque
 from itertools import islice
 from math import sqrt
-
+from collections.abc import Iterable
+from typing import Any
 from rolling.base import RollingObject
-
+from base import WindowType
 
 class Var(RollingObject):
     """
@@ -39,7 +40,7 @@ class Var(RollingObject):
     windows), the variance is computed as NaN.
 
     """
-    def __init__(self, iterable, window_size, window_type="fixed", ddof=1):
+    def __init__(self, iterable: Iterable[Any], window_size: int, window_type: WindowType="fixed", ddof: int=1):
         self.ddof = ddof
         self._mean = 0.0  # mean of values
         self._sslm = 0.0  # sum of squared values less the mean
@@ -57,25 +58,25 @@ class Var(RollingObject):
         # the first call to update returns the correct value
         self._buffer.appendleft(self._mean)
 
-    def _init_variable(self):
+    def _init_variable(self) -> None:
         self._buffer = deque(maxlen=self.window_size)
 
-    def _init_indexed(self):
+    def _init_indexed(self) -> None:
         self._buffer = deque()
 
-    def _add_new(self, new):
+    def _add_new(self, new) -> None:
         self._buffer.append(new)
         delta = new - self._mean
         self._mean += delta / self._obs
         self._sslm += delta * (new - self._mean)
 
-    def _remove_old(self):
+    def _remove_old(self) -> None:
         old = self._buffer.popleft()
         delta = old - self._mean
         self._mean -= delta / self._obs
         self._sslm -= delta * (old - self._mean)
 
-    def _update_window(self, new):
+    def _update_window(self, new) -> None:
         old = self._buffer[0]
         self._buffer.append(new)
         delta = new - old
@@ -95,7 +96,7 @@ class Var(RollingObject):
             return self._sslm / (self._obs - self.ddof)
 
     @property
-    def _obs(self):
+    def _obs(self) -> int:
         return len(self._buffer)
 
 

--- a/rolling/structures/bicounter.py
+++ b/rolling/structures/bicounter.py
@@ -1,8 +1,8 @@
 from collections import defaultdict
-from collections.abc import Mapping
+from collections.abc import Mapping, Iterable
+from typing import Any
 
-
-class BiCounter(Mapping):
+class BiCounter(Mapping[Any, Any]):
     """
     Bi-directional counter.
 
@@ -31,9 +31,9 @@ class BiCounter(Mapping):
 
     """
 
-    def __init__(self, iterable=None):
-        self.item_to_freq = defaultdict(lambda: 0)
-        self.freq_to_items = defaultdict(set)
+    def __init__(self, iterable: Iterable[Any] | None=None) -> None:
+        self.item_to_freq: defaultdict[Any, int] = defaultdict(lambda: 0)
+        self.freq_to_items: defaultdict[int, set[Any]] = defaultdict(set)
         self.largest_count = 0
         if iterable is not None:
             for item in iterable:

--- a/rolling/structures/skiplist.py
+++ b/rolling/structures/skiplist.py
@@ -26,12 +26,12 @@ and allows a value to be retrieved by rank.
 """
 from random import random
 from math import log, ceil
-
+from typing import Any
 
 class Node(object):
     __slots__ = "value", "next", "width"
 
-    def __init__(self, value, next, width):
+    def __init__(self, value: Any, next: Any, width: Any):
         self.value, self.next, self.width = value, next, width
 
 
@@ -58,12 +58,12 @@ class IndexableSkiplist(object):
     Sorted collection supporting O(lg n) insertion, removal, and lookup by rank.
     """
 
-    def __init__(self, expected_size):
+    def __init__(self, expected_size: int):
         self.size = 0
         self.maxlevels = int(1 + log(expected_size, 2))
         self.head = Node("HEAD", [NIL] * self.maxlevels, [1] * self.maxlevels)
 
-    def __getitem__(self, i):
+    def __getitem__(self, i: int):
         node = self.head
         i += 1
         for level in reversed(range(self.maxlevels)):
@@ -84,7 +84,7 @@ class IndexableSkiplist(object):
             chain[level] = node
 
         # insert a link to the newnode at each level
-        d = min(self.maxlevels, 1 - int(log(random(), 2.0)))
+        d: int = min(self.maxlevels, 1 - int(log(random(), 2.0)))
         newnode = Node(value, [None] * d, [None] * d)
         steps = 0
         for level in range(d):

--- a/uv.lock
+++ b/uv.lock
@@ -1,8 +1,0 @@
-version = 1
-revision = 3
-requires-python = ">=3.13"
-
-[[package]]
-name = "rolling"
-version = "0.1.0"
-source = { virtual = "." }

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,8 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"
+
+[[package]]
+name = "rolling"
+version = "0.1.0"
+source = { virtual = "." }


### PR DESCRIPTION
# Overview

- Added typing signatures for all public classes
- Added Literals for Tracker and WindowType for convenient autocompletion
- Deleted redundant and costly runtime isinstance check for arguments types in base class since the LSP and types checker will flag it
- Added some typing for internal variables and functions

## Notes

I used Any in a lot of situation since the docstrings and the internal implementations weren't in conflict with this. 

However with some guidance I could change this very easily. I `assume` that most of the time floats and int are expected in the stats functions for example, henceforth this could easily be changed, and would also allow a way easier conversion into a faster implementation (numba, cython, or may I say Rust)?

Making the classes generics to hint the return type (int->int, float->float, int|float -> float in Sum) would be for example the natural next step.

Also I haven't run pytest, since I haven't changed any actual runtime code, only added annotations, this shouldn't have changed anything. 

My test was just to run a quick script at the root to ensure that no import conflict error were created

Happy to hear feedback and contribute more, because I will use this lib in my own project https://github.com/OutSquareCapital/pychain and made some similar works here https://github.com/OutSquareCapital/rustats which could help as a base example of how to reimplement the code here in Rust